### PR TITLE
Update NumPy version to avoid CVE vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ itsdangerous==1.1.0
 Jinja2==2.11.1
 joblib==0.14.1
 MarkupSafe==1.1.1
-numpy==1.16
+numpy==1.16.3
 packaging==20.1
 pandas==1.0.0
 Pillow==7.0.0


### PR DESCRIPTION
CVE-2019-6446 vulnerability has been published in https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=numpy. NumPy 1.16.0 uses the pickle Python module unsafely, which allows remote attackers to execute arbitrary code via a crafted serialized object, as demonstrated by a numpy.load call.
The issue has been solved from version 1.16.3+. No further changes are needed.

***IMPORTANT*** 
Third parties dispute this issue because it is a behavior that might have legitimate applications in (for example) loading serialized Python object arrays from trusted and authenticated sources. 
If you believe that this behavior is desirable, you may not want to update the dependency.